### PR TITLE
Set the tag for the generator base image to latest

### DIFF
--- a/Dockerfile.generator
+++ b/Dockerfile.generator
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/ci/toolchain-python35:cd1x5f402d7
+FROM registry.opensource.zalan.do/ci/toolchain-python35:latest
 RUN apt-get update && apt-get install -y libssl-dev gnuplot
 RUN pip3 install clickclick jinja2 stups-zign
 COPY plot.py /


### PR DESCRIPTION
There are a couple of fixable vulnerabilities in the generator image. This should avoid those issues in the future.