### PR TITLE
Added filtering for products based on product group.

### DIFF
--- a/app/handler/product.py
+++ b/app/handler/product.py
@@ -10,12 +10,18 @@ from app.utils import strip_column_prefix, slugger
 logger = logging.getLogger('slo-product')
 
 
-def get():
+def get(pg):
     with dbconn() as conn:
         cur = conn.cursor()
+        param_dict = {}
+        if pg:
+            param_dict['pg'] = pg
+            clause = ' AND pg_slug = %(pg)s '
+        else:
+            clause = ''
         cur.execute('''SELECT p.*, pg_name AS pg_product_group_name, pg_slug AS pg_product_group_slug, pg_department
-                FROM zsm_data.product p
-                JOIN zsm_data.product_group ON pg_id = p_product_group_id''')
+                FROM zsm_data.product p, zsm_data.product_group pg WHERE pg_id = p_product_group_id''' + clause,
+                    param_dict)
         rows = cur.fetchall()
         res = [strip_column_prefix(r._asdict()) for r in rows]
     return res

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -61,6 +61,13 @@ paths:
     get:
       tags: [Product]
       operationId: app.handler.product.get
+      parameters:
+        - name: pg
+          type: string
+          in: query
+          description: Product Group slug filter.
+          required: false
+          default: ''
       responses:
         200:
           description: List of products


### PR DESCRIPTION
I've added a query parameter which can be used to filter for a products belonging to a particular product group. I've done this assuming that I would like to get all my products at once so that the reports for all them can be generated at the same time. If this use case is too specific then I can work around it as well but thought this would be nice to have.

@mohabusama I know you're reworking the API and I hope this is not too disruptive.