### PR TITLE
Feature/product group reportts

### DIFF
--- a/generate-slr.py
+++ b/generate-slr.py
@@ -178,7 +178,8 @@ def cli(base_url, product, product_group, output_dir):
         generate_weekly_report(base_url, product, output_dir)
     else:
         url = '{}/products'.format(base_url, product)
-        resp = requests.get(url, headers={'Authorization': 'Bearer {}'.format(zign.api.get_token('zmon', ['uid']))}, params={'pg': product_group})
+        resp = requests.get(url, headers={'Authorization': 'Bearer {}'.format(zign.api.get_token('zmon', ['uid']))},
+                            params={'pg': product_group})
         resp.raise_for_status()
         products_list = resp.json()
         for p in products_list:


### PR DESCRIPTION
This PR introduces a breaking change for the report generation tool. Now reports can be generated for the entire product group instead of a single product. However the product group or product is specified through a flag.