### PR TITLE
Do not display SLI with no units in Reliability index summary

### DIFF
--- a/generate-slr.py
+++ b/generate-slr.py
@@ -112,7 +112,8 @@ def generate_weekly_report(base_url, product, output_dir):
                 ok = False
             slo['slis'][target['sli_name']] = {
                 'avg': '-' if val is None else '{:.2f} {}'.format(val, target['unit']),
-                'ok': ok
+                'ok': ok,
+                'unit': target['unit'],
             }
 
         slo['data'] = []

--- a/templates/slr-weekly.html
+++ b/templates/slr-weekly.html
@@ -53,14 +53,14 @@
                     <table class="table">
                         <tr>
                             {% for sli in slo.slis.keys() | sort %}
-                                {% if sli != 'requests' %}
+                                {% if slo.slis[sli].unit %}
                                     <th class="sli-caption">{{ sli|sli_title }}</th>
                                 {% endif %}
                             {% endfor %}
                         </tr>
                         <tr>
                             {% for sli in slo.slis.keys() | sort %}
-                                {% if sli != 'requests' %}
+                                {% if slo.slis[sli].unit %}
                                     <td class="sli-large {{ 'red' if not slo.slis[sli].ok }}">{{ slo.slis[sli].avg }}</td>
                                 {% endif %}
                             {% endfor %}


### PR DESCRIPTION
Do not display SLI with no units in Reliability index summary