### PR TITLE
Add minimalistic support for minimum/maximum

### DIFF
--- a/app/slo.py
+++ b/app/slo.py
@@ -107,6 +107,10 @@ def process_sli(product_name, sli_name, sli_def, kairosdb_url, start, end, time_
             for g, entry in values.items():
                 total_value += entry['value']
             res2[minute] = total_value
+        elif aggregation_type == 'minimum':
+            res2[minute] = min([entry['value'] for g, entry in values.items()])
+        elif aggregation_type == 'maximum':
+            res2[minute] = max([entry['value'] for g, entry in values.items()])
 
     for minute, value in sorted(res2.items()):
         dt = datetime.datetime.fromtimestamp(minute)

--- a/cli.py
+++ b/cli.py
@@ -17,7 +17,7 @@ from zmon_cli.client import Zmon
 DEFAULT_CONFIG_FILE = '~/.zmon-slr.yaml'
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
-AGG_TYPES = ('average', 'weighted', 'sum')
+AGG_TYPES = ('average', 'weighted', 'sum', 'minimum', 'maximum')
 
 
 def get_config_data(config_file=DEFAULT_CONFIG_FILE):


### PR DESCRIPTION
To support our own needs, we are adding minimum and maximum.  The change is not really reflected in the frontend, but then it always speaks about weighted average already, without respect to the actual aggregate type used.