### PR TITLE
docs: fix python version in "run the server" section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Run the server
 
 .. code-block:: bash
 
-    python -m app
+    python3 -m app
 
 
 Configuration parameters:


### PR DESCRIPTION
Should use python3 to run the server