### PR TITLE
Gather debug data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ client/build
 build/
 dist/
 .mypy_cache/
+.vscode/

--- a/dockerfiles/Dockerfile.generator
+++ b/dockerfiles/Dockerfile.generator
@@ -13,6 +13,6 @@ COPY MANIFEST.in /
 COPY LICENSE /
 COPY setup.py /
 
-RUN pip install -r requirements.txt && python3 setup.py install
+RUN python3 -m pip install 'opentracing>=1.2.2,<2' && python3 setup.py install
 
 CMD python3 /reports.py

--- a/dockerfiles/Dockerfile.generator
+++ b/dockerfiles/Dockerfile.generator
@@ -13,6 +13,6 @@ COPY MANIFEST.in /
 COPY LICENSE /
 COPY setup.py /
 
-RUN python3 setup.py install
+RUN pip install -r requirements.txt && python3 setup.py install
 
 CMD python3 /reports.py

--- a/zmon_slr/generate_slr.py
+++ b/zmon_slr/generate_slr.py
@@ -1,19 +1,16 @@
 #!/usr/bin/env python3
 
 import datetime
-import os
-import time
 import logging
+import os
 import sys
+import time
+from collections import defaultdict
 
 import jinja2
 
-from collections import defaultdict
-
 from zmon_slr.client import Client
-
 from zmon_slr.plot import plot
-
 
 AGGS_MAP = {
     'average': 'avg',
@@ -206,6 +203,7 @@ def generate_weekly_report(client: Client, product: dict, output_dir: str) -> No
                 slis[sli]['unit'] = unit
                 slis[sli]['classes'] = classes
                 slis[sli]['aggregate'] = '{:.2f} {}'.format(get_aggregate(aggregation, sli_data), unit)
+
 
             dt = datetime.datetime.strptime(day[:10], '%Y-%m-%d')
             dow = dt.strftime('%a')

--- a/zmon_slr/generate_slr.py
+++ b/zmon_slr/generate_slr.py
@@ -204,7 +204,6 @@ def generate_weekly_report(client: Client, product: dict, output_dir: str) -> No
                 slis[sli]['classes'] = classes
                 slis[sli]['aggregate'] = '{:.2f} {}'.format(get_aggregate(aggregation, sli_data), unit)
 
-
             dt = datetime.datetime.strptime(day[:10], '%Y-%m-%d')
             dow = dt.strftime('%a')
 

--- a/zmon_slr/plot.py
+++ b/zmon_slr/plot.py
@@ -22,7 +22,10 @@ def save_debug_data(output_file, gnuplot_data, gnuplot_result):
             return
 
         debug_file_path = pathlib.Path(f"{output_file_path}.debug.json")
-        print(f"Generated graph {output_file} is probably corrupted! Saving troubleshooting data to {debug_file_path}...")
+        print(
+            f"Generated graph {output_file} is probably corrupted! "
+            f"Saving troubleshooting data to {debug_file_path}..."
+        )
         data = {
             "output_file": output_file,
             "gnuplot_data": gnuplot_data,

--- a/zmon_slr/plot.py
+++ b/zmon_slr/plot.py
@@ -1,11 +1,42 @@
 #!/usr/bin/env python3
 
 import collections
+import json
+import logging
+import pathlib
 import subprocess
+import traceback
 
 from zmon_slr.client import Client
 
 precision = {'ms': 0, '%': 2}
+
+
+def save_debug_data(output_file, gnuplot_data, gnuplot_result):
+    """Tries to gather and save debug data. If fails, continues and does not stall further processing.
+    """
+
+    try:
+        output_file_path = pathlib.Path(output_file)
+        filesize = output_file_path.stat().st_size
+        # if filesize:
+        #     return
+
+        debug_file_path = pathlib.Path(f"{output_file_path}.debug.json")
+        print(f"Generated graph {output_file} is probably corrupted! Saving troubleshooting data to {debug_file_path}...")
+        data = {
+            "output_file": output_file,
+            "gnuplot_data": gnuplot_data,
+            "gnuplot_version": subprocess.run(["gnuplot", "-V"], stdout=subprocess.PIPE).stdout.decode().strip(),
+            "gnuplot_result": [item.decode() for item in gnuplot_result],
+            "tsvs": {
+                str(path): path.read_text()
+                for path in pathlib.Path('/tmp').glob('data*.tsv')
+            }
+        }
+        debug_file_path.write_text(json.dumps(data))
+    except: # noqa
+        traceback.print_exc()
 
 
 def plot(client: Client, product: dict, slo_id: int, output_file):
@@ -39,7 +70,7 @@ def plot(client: Client, product: dict, slo_id: int, output_file):
             for row in data:
                 fd.write('{}\t{}\n'.format(row['timestamp'], row['value']))
 
-    plot = subprocess.Popen(['gnuplot'], stdin=subprocess.PIPE)
+    plot = subprocess.Popen(['gnuplot'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     gnuplot_data = '''
     set output '{}'
@@ -95,4 +126,5 @@ def plot(client: Client, product: dict, slo_id: int, output_file):
             plots.append('"{}" using 1:2 lw 2 axes x1{} with lines title "{}"'.format(
                 target['fn'], target['yaxis'], target['sli_name'].replace('_', ' ')))
     gnuplot_data += ', '.join(plots) + '\n'
-    plot.communicate(gnuplot_data.encode('utf-8'))
+    gnuplot_result = plot.communicate(gnuplot_data.encode('utf-8'))
+    save_debug_data(output_file, gnuplot_data, gnuplot_result)

--- a/zmon_slr/plot.py
+++ b/zmon_slr/plot.py
@@ -2,7 +2,6 @@
 
 import collections
 import json
-import logging
 import pathlib
 import subprocess
 import traceback
@@ -19,8 +18,8 @@ def save_debug_data(output_file, gnuplot_data, gnuplot_result):
     try:
         output_file_path = pathlib.Path(output_file)
         filesize = output_file_path.stat().st_size
-        # if filesize:
-        #     return
+        if filesize:
+            return
 
         debug_file_path = pathlib.Path(f"{output_file_path}.debug.json")
         print(f"Generated graph {output_file} is probably corrupted! Saving troubleshooting data to {debug_file_path}...")


### PR DESCRIPTION
In order to generate graphs SLR tool invokes `gnuplot`. Sometimes it ends up with errors which are silently ignored. The end effect is usually an empty graphic file which means missing graph for the users in the SLR reports. With the current code it is impossible to debug because neither we log faulty output from `gnuplot` nor the input that we feed it with.
This PR saves all of those along with the result in case when graph is empty (file size is 0).