### PR TITLE
Fix one of broken images/reports scenario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build/
 dist/
 .mypy_cache/
 .vscode/
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ python:
   - "3.6"
 install:
   - pip install tox
-  - apt-get install -y gnuplot
+  - sudo apt-get install -y gnuplot
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ python:
   - "3.6"
 install:
   - pip install tox
+  - apt-get install -y gnuplot
 script:
   - tox

--- a/analyze_troubleshooting.py
+++ b/analyze_troubleshooting.py
@@ -1,15 +1,24 @@
+"""
+Provided with a path to the file with logs from a reports generator run,
+this script looks for all debug file locations, downloads them from S3 bucket
+and tries to match them to the well-known errors.
+If cannot do so, dumps all the necessary troubleshooting data into OUTPUT_DIR
+in a convenient format.
+"""
 import io
 import json
 import pathlib
 import re
+import shutil
 import sys
 
 import boto3
 
 S3_BUCKET='zalando-slr-service-level-reporting-s3-bucket'
 FILEPATH_PATTERN = re.compile(r"([\w/\-.]+(?:\.debug\.json|.tsv))")
-OUTPUT_DIR = pathlib.Path('output/')
-OUTPUT_DIR.mkdir(exist_ok=True)
+YRANGE_TOO_SMALL = re.compile(r"set\s+yrange\s+\[(.+):\1\]")
+OUTPUT_DIR = pathlib.Path('troubleshooting/')
+shutil.rmtree(OUTPUT_DIR, ignore_errors=True)
 
 s3 = boto3.client('s3')
 
@@ -18,22 +27,37 @@ for line in log_file:
     filepath = FILEPATH_PATTERN.findall(line)
     if not filepath:
         continue
-    filepath = filepath[0][5:]
+    filepath = filepath[0].replace('/var/', '')
 
     stream = io.BytesIO()
     s3.download_fileobj(S3_BUCKET, filepath, stream)
-    output_path = OUTPUT_DIR / filepath
-    output_path.parent.mkdir(exist_ok=True, parents=True)
-    output_path.write_bytes(stream.getvalue())
 
     tb_data = json.loads(stream.getvalue())
     gnuplot_result = ''.join(tb_data['gnuplot_result']).strip()
-    tsvpath = FILEPATH_PATTERN.findall(gnuplot_result)
-    if tsvpath:
-        tsvpath = tsvpath[0]
-        tsv = tb_data['tsvs'][tsvpath]
-    else:
-        for name, content in tb_data['tsvs'].items():
-            tsv += f'{name}\n{content}\n\n'
+    gnuplot_data = tb_data['gnuplot_data']
 
-    print(f"{filepath}\n\nGnuplot result:\n{gnuplot_result}\n\nTSV:\n{tsv}\n-------")
+    issues = set()
+    if YRANGE_TOO_SMALL.findall(tb_data['gnuplot_data']):
+        issues.add('YRANGE_TOO_SMALL')
+
+    tsv_paths = FILEPATH_PATTERN.findall(gnuplot_data)
+    for tsv_path in tsv_paths:
+        tsv = tb_data['tsvs'][tsv_path]
+        if not tsv:
+            issues.add('NO_SLI_VALUES')
+
+    if not issues:
+        issues.add('N/A')
+        OUTPUT_DIR.mkdir(exist_ok=True)
+
+        output_path = OUTPUT_DIR / (filepath.replace('/', '_'))
+        output_path.mkdir()
+        (output_path / 'tb_data.json').write_bytes(stream.getvalue())
+
+        (output_path / 'gnuplot_result').write_text(gnuplot_result)
+        (output_path / 'gnuplot_data').write_text(gnuplot_data)
+        
+        for tsv_path in FILEPATH_PATTERN.findall(gnuplot_data):
+            (output_path / tsv_path.replace('/', '_')).write_text(tb_data['tsvs'][tsv_path])
+
+    print(f"{filepath:180} {','.join(issues)}")

--- a/analyze_troubleshooting.py
+++ b/analyze_troubleshooting.py
@@ -1,0 +1,39 @@
+import io
+import json
+import pathlib
+import re
+import sys
+
+import boto3
+
+S3_BUCKET='zalando-slr-service-level-reporting-s3-bucket'
+FILEPATH_PATTERN = re.compile(r"([\w/\-.]+(?:\.debug\.json|.tsv))")
+OUTPUT_DIR = pathlib.Path('output/')
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+s3 = boto3.client('s3')
+
+log_file = open(sys.argv[1])
+for line in log_file:
+    filepath = FILEPATH_PATTERN.findall(line)
+    if not filepath:
+        continue
+    filepath = filepath[0][5:]
+
+    stream = io.BytesIO()
+    s3.download_fileobj(S3_BUCKET, filepath, stream)
+    output_path = OUTPUT_DIR / filepath
+    output_path.parent.mkdir(exist_ok=True, parents=True)
+    output_path.write_bytes(stream.getvalue())
+
+    tb_data = json.loads(stream.getvalue())
+    gnuplot_result = ''.join(tb_data['gnuplot_result']).strip()
+    tsvpath = FILEPATH_PATTERN.findall(gnuplot_result)
+    if tsvpath:
+        tsvpath = tsvpath[0]
+        tsv = tb_data['tsvs'][tsvpath]
+    else:
+        for name, content in tb_data['tsvs'].items():
+            tsv += f'{name}\n{content}\n\n'
+
+    print(f"{filepath}\n\nGnuplot result:\n{gnuplot_result}\n\nTSV:\n{tsv}\n-------")

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -20,7 +20,8 @@ pipeline:
             libffi-dev \
             libssl-dev \
             libpq-dev \
-            tox
+            tox \
+            gnuplot
           update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1
           update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1
 

--- a/tests/integration/test_plot.py
+++ b/tests/integration/test_plot.py
@@ -1,0 +1,32 @@
+import collections
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from zmon_slr.plot import plot
+
+SLO = collections.namedtuple('SLO', 'from_ to sli_values')
+
+
+@pytest.fixture(params=[
+    pytest.param(SLO(100, 100, [100 for _ in range(50)]), id='SLI values constant and equal to SLO target'),
+])
+def client_mock(request):
+    mock = MagicMock()
+    mock.slo_list = MagicMock(return_value=[{}])
+    mock.target_list = MagicMock(return_value=[{'sli_name': 'sample-sli-1', 'from': request.param.from_, 'to': request.param.to}])
+    mock.sli_list = MagicMock(return_value=[{'unit': '%'}])
+    mock.sli_values = MagicMock(return_value=[
+        {'value': value, 'timestamp': datetime.fromtimestamp(i).isoformat()}
+        for i, value in enumerate(request.param.sli_values)
+    ])
+
+    return mock
+
+
+def test_graph_is_not_corrupted(client_mock, tmpdir):
+    graph_file = tmpdir / 'graph.png'
+    plot(client_mock, {}, 0, str(graph_file))
+
+    assert graph_file.size() > 0, 'Graph file size was zero'

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,8 @@ deps=
     pytest
     pytest_cov
     codecov>=1.4.0
-
-# TODO: Add tests
+usedevelop=true
 commands=
     flake8 app zmon_slr dockerfiles
+    pytest -v --cov=app --cov=zmon_slr tests/
 

--- a/zmon_slr/plot.py
+++ b/zmon_slr/plot.py
@@ -72,7 +72,7 @@ def plot(client: Client, product: dict, slo_id: int, output_file):
             for row in data:
                 fd.write('{}\t{}\n'.format(row['timestamp'], row['value']))
 
-    plot = subprocess.Popen(['gnuplot'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    gnuplot = subprocess.Popen(['gnuplot'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     gnuplot_data = '''
     set output '{}'
@@ -100,7 +100,7 @@ def plot(client: Client, product: dict, slo_id: int, output_file):
 
             ymin, ymax = (min(from_list + min_list), max(to_list + max_list))
 
-            padding = (0.1 * (ymax - ymin))
+            padding = (0.1 * ((ymax - ymin) or ymin))
             ymin = ymin - padding
             ymax = ymax + padding
 
@@ -128,5 +128,5 @@ def plot(client: Client, product: dict, slo_id: int, output_file):
             plots.append('"{}" using 1:2 lw 2 axes x1{} with lines title "{}"'.format(
                 target['fn'], target['yaxis'], target['sli_name'].replace('_', ' ')))
     gnuplot_data += ', '.join(plots) + '\n'
-    gnuplot_result = plot.communicate(gnuplot_data.encode('utf-8'))
+    gnuplot_result = gnuplot.communicate(gnuplot_data.encode('utf-8'))
     save_debug_data(output_file, gnuplot_data, gnuplot_result)


### PR DESCRIPTION
- adds an integration test to check if gnuplot instructions actually end up with generating an image (not an empty file)
- fixes the `tox` run in CI pipelines (in addition adds `gnuplot` dep for the integration test)
- adds script that based on generator logs analyzes troubleshooting data