### PR TITLE
Show a proper error message instead of broken graph when there is no data for SLI

### DIFF
--- a/zmon_slr/generate_slr.py
+++ b/zmon_slr/generate_slr.py
@@ -211,9 +211,14 @@ def generate_weekly_report(client: Client, product: dict, output_dir: str) -> No
 
         slo['breaches'] = max_or_zero(breaches_by_sli.values())
         slo['count'] = max_or_zero(counts_by_sli.values())
+        slo['no_data'] = []
 
         for target in slo['targets']:
             sli_name = target['sli_name']
+
+            if not counts_by_sli.get(sli_name):
+                slo['no_data'].append(sli_name)
+
             aggregation = target['aggregation']
 
             val = None

--- a/zmon_slr/templates/slr-weekly.html
+++ b/zmon_slr/templates/slr-weekly.html
@@ -107,9 +107,7 @@
                             </ul>
                         </p>
                         <p>
-                            If you believe this is a bug, please feel free to <a
-                                href="https://github.bus.zalan.do/eagleeye/SLR/issues/new/choose">open a support
-                                request</a> with us.
+                            If you believe this is a bug, please feel free to open a support request with us.
                         </p>
                     </div>
                     {% else %}

--- a/zmon_slr/templates/slr-weekly.html
+++ b/zmon_slr/templates/slr-weekly.html
@@ -1,68 +1,132 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <title>Service Level Report - {{ period }}</title>
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
-          integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+        integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 
     <!-- Optional theme -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css"
-          integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+        integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
 
     <!-- Latest compiled and minified JavaScript -->
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
-            integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
-            crossorigin="anonymous"></script>
+        integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
+        crossorigin="anonymous"></script>
     <link href="https://fonts.googleapis.com/css?family=Merriweather|Roboto" rel="stylesheet">
     <style>
         body {
             font-family: 'Roboto', sans-serif;
         }
 
-        h1, h2, h3, h4, h5, h6 {
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
             font-family: 'Merriweather', serif;
         }
 
-        table.report td, th.day { text-align: center;}
-        td.ok { }
-        td.orange { background-color: #ffffc8; }
-        td.red { background-color: #ffcece; }
-        td.not-enough-samples { opacity: 0.7; }
+        table.report td,
+        th.day {
+            text-align: center;
+        }
 
-        .sli-large { font-size: 48px; }
+        td.ok {}
 
-        .chart { text-align: center; }
+        td.orange {
+            background-color: #ffffc8;
+        }
 
+        td.red {
+            background-color: #ffcece;
+        }
+
+        td.not-enough-samples {
+            opacity: 0.7;
+        }
+
+        .sli-large {
+            font-size: 48px;
+        }
+
+        .chart {
+            text-align: center;
+        }
+
+        .slo-problems {
+            margin-top: 10px;
+            color: red;
+        }
     </style>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 </head>
+
 <body>
-<div class="container-fluid">
-    <div class="container">
-        <div class="page-header">
-            <h1>Service Levels Report</h1>
-            <h3>{{ product.product_group_name }} - {{ product.name }}</h3>
-            <h4>{{ period }}</h4>
-        </div>
-        {% for slo in slos %}
+    <div class="container-fluid">
+        <div class="container">
+            <div class="page-header">
+                <h1>Service Levels Report</h1>
+                <h3>{{ product.product_group_name }} - {{ product.name }}</h3>
+                <h4>{{ period }}</h4>
+            </div>
+            {% for slo in slos %}
             <div class="panel panel-default">
-                <div class="panel-heading"><h4>{{ slo.title }}</h4></div>
+                <div class="panel-heading">
+                    <h4>{{ slo.title }}</h4>
+                </div>
                 <div class="panel-body">
                     <div>{{ slo.description }}</div>
+
+                    {% if slo.no_data %}
+                    <div class="slo-problems">
+                        <p>
+                            Unfortunately we were unable to generate this section of the report.<br>
+                            There were no data points collected for the following SLIs:
+                            <ul>
+                                {% for sli_name in slo.no_data %}
+                                <li>{{ sli_name }}</li>
+                                {% endfor %}
+                            </ul>
+                        </p>
+                        <p>
+                            Possible reasons include:
+                            <ul>
+                                <li>A check referred by the SLI definition does not exist or does not collect any data
+                                    (is in state <span class="monospace">INACTIVE</span>, has no alerts defined, etc.)
+                                </li>
+                                <li>
+                                    Some keys referred by the SLI definition do not exist in check results.
+                                </li>
+                                <li>
+                                    Nonexistent tags (or their values) are used in the SLI definition.
+                                </li>
+                            </ul>
+                        </p>
+                        <p>
+                            If you believe this is a bug, please feel free to <a
+                                href="https://github.bus.zalan.do/eagleeye/SLR/issues/new/choose">open a support
+                                request</a> with us.
+                        </p>
+                    </div>
+                    {% else %}
                     <table class="table">
                         <tr>
                             {% for sli in slo.slis.keys() | sort %}
-                                {% if slo.slis[sli].unit %}
-                                    <th class="sli-caption">{{ sli|sli_title }}</th>
-                                {% endif %}
+                            {% if slo.slis[sli].unit %}
+                            <th class="sli-caption">{{ sli|sli_title }}</th>
+                            {% endif %}
                             {% endfor %}
                         </tr>
                         <tr>
                             {% for sli in slo.slis.keys() | sort %}
-                                {% if slo.slis[sli].unit %}
-                                    <td class="sli-large {{ 'red' if not slo.slis[sli].ok }}">{{ slo.slis.get(sli).aggregate }}</td>
-                                {% endif %}
+                            {% if slo.slis[sli].unit %}
+                            <td class="sli-large {{ 'red' if not slo.slis[sli].ok }}">{{ slo.slis.get(sli).aggregate }}
+                            </td>
+                            {% endif %}
                             {% endfor %}
                         </tr>
                     </table>
@@ -71,28 +135,32 @@
                         <tr>
                             <th>SLI</th>
                             {% for data in slo.data %}
-                                <th class="day">{{ data.caption|sli_title }}</th>
+                            <th class="day">{{ data.caption|sli_title }}</th>
+                            {% else %}
+                            <th class="day">N/A</th>
                             {% endfor %}
                         </tr>
 
                         {% for sli in slo.slis.keys()|sort %}
-                            <tr>
-                                <th>{{ sli|sli_title }}</th>
-                                {% for data in slo.data %}
-                                    {% if data.slis.get(sli) %}
-                                        <td class="value {{ ' '.join(data.slis.get(sli).classes) }}"
-                                            title="min: {{ data.slis.get(sli).min }}, max: {{ data.slis.get(sli).max }}, breaches: {{ data.slis.get(sli).breaches }}, count: {{ data.slis.get(sli).count }}">
-                                        {% if 'total' in data.slis.get(sli) %}
-                                            {{ '{:,}'.format(data.slis.get(sli).total) }}
-                                        {% else %}
-                                            {{ data.slis.get(sli).aggregate }}
-                                        {% endif %}
-                                        </td>
-                                    {% else %}
-                                        <td></td>
-                                    {% endif %}
-                                {% endfor %}
-                            </tr>
+                        <tr>
+                            <th>{{ sli|sli_title }}</th>
+                            {% for data in slo.data %}
+                            {% if data.slis.get(sli) %}
+                            <td class="value {{ ' '.join(data.slis.get(sli).classes) }}"
+                                title="min: {{ data.slis.get(sli).min }}, max: {{ data.slis.get(sli).max }}, breaches: {{ data.slis.get(sli).breaches }}, count: {{ data.slis.get(sli).count }}">
+                                {% if 'total' in data.slis.get(sli) %}
+                                {{ '{:,}'.format(data.slis.get(sli).total) }}
+                                {% else %}
+                                {{ data.slis.get(sli).aggregate }}
+                                {% endif %}
+                            </td>
+                            {% else %}
+                            <td></td>
+                            {% endif %}
+                            {% else %}
+                            <td><em>No data points</em></td>
+                            {% endfor %}
+                        </tr>
                         {% endfor %}
                     </table>
 
@@ -105,19 +173,26 @@
                         </tr>
                     </table>
                     <p class="chart">
-                        <img src="{{ slo.chart }}" alt="Service Level Objective Chart"/>
+                        <img src="{{ slo.chart }}" alt="Service Level Objective Chart" />
                     </p>
                     {% if slo.breaches %}
-                    <div class="alert alert-danger"><p>During this period, the service failed to meet this SLO for <strong title="{{ slo.breaches }} minute(s)">{{ slo.breaches|human_time }}</strong>.
-                        The SLO was not met for <strong>{{ '%.2f'|format(slo.breaches/slo.count * 100) }} %</strong> of the observed time.</p></div>
+                    <div class="alert alert-danger">
+                        <p>During this period, the service failed to meet this SLO for <strong
+                                title="{{ slo.breaches }} minute(s)">{{ slo.breaches|human_time }}</strong>.
+                            The SLO was not met for <strong>{{ '%.2f'|format(slo.breaches/slo.count * 100) }} %</strong>
+                            of the observed time.</p>
+                    </div>
+                    {% endif %}
                     {% endif %}
                 </div>
             </div>
-        {% endfor %}
-        <footer>
-            <p class="text-muted">All dates and times are in UTC. Report generated on {{ now.strftime('%Y-%m-%d %H:%M UTC') }}.</p>
-        </footer>
+            {% endfor %}
+            <footer>
+                <p class="text-muted">All dates and times are in UTC. Report generated on
+                    {{ now.strftime('%Y-%m-%d %H:%M UTC') }}.</p>
+            </footer>
+        </div>
     </div>
-</div>
 </body>
+
 </html>

--- a/zmon_slr/templates/slr-weekly.html
+++ b/zmon_slr/templates/slr-weekly.html
@@ -95,7 +95,8 @@
                         <p>
                             Possible reasons include:
                             <ul>
-                                <li>A check referred by the SLI definition does not exist or does not collect any data
+                                <li>
+                                    A check referred by the SLI definition does not exist or does not collect any data
                                     (is in state <span class="monospace">INACTIVE</span>, has no alerts defined, etc.)
                                 </li>
                                 <li>


### PR DESCRIPTION
Show a proper error message instead of broken graph when there is no data for SLI.
Before:
![Screen Shot 2019-12-16 at 5 57 53 PM](https://user-images.githubusercontent.com/3660963/70926591-ab6ebd80-202d-11ea-9760-ed04a16d591c.png)
After:
![Screen Shot 2019-12-16 at 5 55 19 PM](https://user-images.githubusercontent.com/3660963/70926396-55017f00-202d-11ea-81e8-65781759698e.png)

