### PR TITLE
Add p95 for latency for LightStep as it's common enough

### DIFF
--- a/app/resources/sli/sources/lightstep.py
+++ b/app/resources/sli/sources/lightstep.py
@@ -87,6 +87,7 @@ class _Metric(enum.Enum):
     LATENCY_P50 = _Latency("50")
     LATENCY_P75 = _Latency("75")
     LATENCY_P90 = _Latency("90")
+    LATENCY_P95 = _Latency("95")
     LATENCY_P99 = _Latency("99")
 
     @classmethod

--- a/zmon_slr/main.py
+++ b/zmon_slr/main.py
@@ -27,6 +27,7 @@ LIGHTSTEP_METRICS = (
     "latency_p50",
     "latency_p75",
     "latency_p90",
+    "latency_p95",
     "latency_p99"
 )
 
@@ -738,7 +739,7 @@ def validate_lightstep_source(config, source, act: Action, ignore_keys=False):
     if missing:
         act.error('Fields {} are missing in SLI source definition.'.format(missing))
     metric = source.get('metric', '')
-    if metric not in LIGHTSTEP_METRICS:
+    if metric.lower() not in LIGHTSTEP_METRICS:
         act.error('"source.metric is invalid.'.format(missing))
     return None
 


### PR DESCRIPTION
Latency at 95th percentile is common enough to add it for LightStep integration. Also it is a part of the current "Kubernetes check" used as a source for ZMON SLIs re latency.