### PR TITLE
Block older version of limits, because a new one is faulty

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ dataclasses==0.7
 datetime_truncate
 Flask-Cache>=0.13.1
 Flask-limiter==0.9.4
+limits==1.4.1
 Flask-Migrate==2.0.4
 Flask-OAuthlib==0.9.4
 Flask-Session==0.3.1


### PR DESCRIPTION
New version of this dependency breaks our application, so we block to use an older one.