### PR TITLE
Support reports backfilling by specyfing custom 'to' datetime and improves reports endpoint performance

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -4,7 +4,7 @@ import redis
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 
-DEBUG = os.getenv('DEBUG', False)
+DEBUG = bool(os.getenv('DEBUG', False))
 SLR_LOCAL_ENV = os.environ.get('SLR_LOCAL_ENV')
 
 # APP

--- a/app/main.py
+++ b/app/main.py
@@ -91,6 +91,8 @@ def register_extensions(app: flask.Flask) -> None:
     session.init_app(app)
     oauth.init_app(app)
 
+    app.config['SQLALCHEMY_ECHO'] = True
+
     trace_flask(app, operation_name=get_operation_name, skip_span=request_skip_span)
     trace_sqlalchemy(skip_span=sqlalchemy_skip_span)
 

--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,7 @@ from app.config import (
     APP_SESSION_SECRET,
     CACHE_THRESHOLD,
     CACHE_TYPE,
+    DEBUG,
     MAX_RETENTION_DAYS,
     OPENTRACING_TRACER,
     RUN_UPDATER,
@@ -82,7 +83,9 @@ def create_app(*args, **kwargs):
 def register_extensions(app: flask.Flask) -> None:
     app.secret_key = APP_SESSION_SECRET
 
+    app.config['SQLALCHEMY_ECHO'] = DEBUG
     db.init_app(app)
+
     migrate.init_app(app, db)
     cache.init_app(
         app, config={'CACHE_TYPE': CACHE_TYPE, 'CACHE_THRESHOLD': CACHE_THRESHOLD}
@@ -90,8 +93,6 @@ def register_extensions(app: flask.Flask) -> None:
     limiter.init_app(app)
     session.init_app(app)
     oauth.init_app(app)
-
-    app.config['SQLALCHEMY_ECHO'] = True
 
     trace_flask(app, operation_name=get_operation_name, skip_span=request_skip_span)
     trace_sqlalchemy(skip_span=sqlalchemy_skip_span)

--- a/app/resources/report/api.py
+++ b/app/resources/report/api.py
@@ -8,8 +8,11 @@ from connexion import ProblemException
 from datetime_truncate import truncate as truncate_datetime
 from dateutil.relativedelta import relativedelta
 from opentracing.ext import tags as ot_tags
-from opentracing_utils import (extract_span_from_flask_request,
-                               extract_span_from_kwargs, trace)
+from opentracing_utils import (
+    extract_span_from_flask_request,
+    extract_span_from_kwargs,
+    trace,
+)
 from sqlalchemy.orm import joinedload
 
 from app.libs.resource import ResourceHandler
@@ -22,7 +25,7 @@ REPORT_TYPES = ('weekly', 'monthly', 'quarterly')
 
 
 def get_report_params(
-    report_type, to_dt=None,
+    report_type, to_dt,
 ) -> Tuple[sources.DatetimeRange, sources.Resolution]:
     if report_type == "weekly":
         from_dt = to_dt - relativedelta(days=7)
@@ -164,10 +167,10 @@ class ReportResource(ResourceHandler):
         product_id = kwargs.get('product_id')
         product = Product.query.get_or_404(product_id)
 
-        to_str = kwargs.get('period_to')
-        if to_str:
+        period_to = kwargs.get('period_to')
+        if period_to:
             try:
-                to_dt = dateutil.parser.parse(to_str, ignoretz=True)
+                to_dt = dateutil.parser.parse(period_to, ignoretz=True)
             except:  # noqa
                 raise ProblemException(
                     status=400,

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1113,6 +1113,10 @@ paths:
           in: path
           required: true
           description: Report type [weekly, monthly, quarterly].
+        - name: period_to
+          type: string
+          in: query
+          description: Specify end of time period for the report (in ISO-8601 format)
       responses:
         200:
           description: Generated report

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1119,7 +1119,7 @@ paths:
           description: |
             Specify the end of time period for the report (in ISO-8601 format).
             Given timezone is ignored and always replaced with UTC.
-          example: '2020-01-13T12:03:15Z'
+            Example: '2020-01-13T12:03:15Z'
       responses:
         200:
           description: Generated report

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1116,7 +1116,10 @@ paths:
         - name: period_to
           type: string
           in: query
-          description: Specify end of time period for the report (in ISO-8601 format)
+          description: |
+            Specify the end of time period for the report (in ISO-8601 format).
+            Given timezone is ignored and always replaced with UTC.
+          example: '2020-01-13T12:03:15Z'
       responses:
         200:
           description: Generated report

--- a/zmon_slr/client.py
+++ b/zmon_slr/client.py
@@ -1,8 +1,7 @@
-import requests
-
-from typing import List
-
+from typing import List, Optional
 from urllib.parse import urljoin
+
+import requests
 
 
 class SLRClientError(Exception):
@@ -15,7 +14,12 @@ class Client:
         self.token = token
 
         self.session = requests.Session()
-        self.session.headers.update({'Authorization': 'Bearer {}'.format(token), 'User-Agent': 'slr-cli/0.1-alpha'})
+        self.session.headers.update(
+            {
+                'Authorization': 'Bearer {}'.format(token),
+                'User-Agent': 'slr-cli/0.1-alpha',
+            }
+        )
 
         # Load root URIs
         resp = self.session.get(self.url)
@@ -26,7 +30,9 @@ class Client:
         self.PRODUCT_GROUPS = api['product_groups_uri']
         self.PRODUCTS = api['products_uri']
 
-    def product_list(self, name=None, product_group_name=None, limit=100, q=None) -> List[dict]:
+    def product_list(
+        self, name=None, product_group_name=None, limit=100, q=None
+    ) -> List[dict]:
         params = {} if not name else {'name': name}
 
         if q:
@@ -95,10 +101,7 @@ class Client:
         return res
 
     def product_group_create(self, name, department) -> dict:
-        data = {
-            'name': name,
-            'department': department or ''
-        }
+        data = {'name': name, 'department': department or ''}
 
         res = self.session.post(self.PRODUCT_GROUPS, json=data)
         res.raise_for_status()
@@ -132,10 +135,7 @@ class Client:
         return res
 
     def slo_create(self, product: dict, title: str, description: str) -> dict:
-        slo = {
-            'title': title,
-            'description': description
-        }
+        slo = {'title': title, 'description': description}
 
         res = self.session.post(product['product_slo_uri'], json=slo)
         res.raise_for_status()
@@ -170,12 +170,10 @@ class Client:
 
         return res
 
-    def target_create(self, slo: dict, sli_uri: str, target_from=0.0, target_to=0.0) -> dict:
-        target = {
-            'from': target_from,
-            'to': target_to,
-            'sli_uri': sli_uri
-        }
+    def target_create(
+        self, slo: dict, sli_uri: str, target_from=0.0, target_to=0.0
+    ) -> dict:
+        target = {'from': target_from, 'to': target_to, 'sli_uri': sli_uri}
 
         res = self.session.post(slo['slo_targets_uri'], json=target)
         res.raise_for_status()
@@ -213,11 +211,7 @@ class Client:
         return res
 
     def sli_create(self, product: dict, name: str, unit: str, source: dict) -> dict:
-        sli = {
-            'name': name,
-            'source': source,
-            'unit': unit
-        }
+        sli = {'name': name, 'source': source, 'unit': unit}
 
         res = self.session.post(product['product_sli_uri'], json=sli)
         res.raise_for_status()
@@ -257,8 +251,13 @@ class Client:
 
         return res.json()
 
-    def product_report(self, product: dict) -> dict:
-        resp = self.session.get(product['product_reports_weekly_uri'], timeout=180)
+    def product_report(self, product: dict, period_to: Optional[str] = None) -> dict:
+        params = {}
+        if period_to:
+            params['period_to'] = period_to
+        resp = self.session.get(
+            product['product_reports_weekly_uri'], params=params, timeout=180
+        )
 
         resp.raise_for_status()
 

--- a/zmon_slr/generate_slr.py
+++ b/zmon_slr/generate_slr.py
@@ -6,6 +6,7 @@ import os
 import sys
 import time
 from math import ceil
+from typing import Optional
 
 import jinja2
 
@@ -123,8 +124,10 @@ def parse_report_timestamp(timestamp):
     return datetime.datetime.strptime(timestamp[:10], '%Y-%m-%d')
 
 
-def generate_weekly_report(client: Client, product: dict, output_dir: str) -> None:
-    report_data = call_and_retry(client.product_report, product)
+def generate_weekly_report(
+    client: Client, product: dict, output_dir: str, period_to_str: Optional[str] = None
+) -> None:
+    report_data = call_and_retry(client.product_report, product, period_to_str)
 
     product_group = report_data['product_group_slug']
 


### PR DESCRIPTION
- Support reports backfilling by specyfing custom 'to' datetime.
Due to an automatic update of a faulty dependency (more in [this issue](https://github.com/zalando-zmon/service-level-reporting/pull/173) fixing it) we lost reports for the last 5 days. Currently there is not way to 'backfill' those reports because API does not support providing a custom time range end; basically it assumes reports will be generated for `<now - 7 days; now>` where `now` is the exact time of running the generation script. This PR adds support for the custom time range end. 
- Optimizes queries and fixes a performance regression when `/report/weekly` endpoint is hit
  - Namely indicator values were prefetched by `indicator.id` and stored in `aggregates` however did not take into account that some of those indicators didn't have any objectives attached, thus fetched a lot useless data, wasted resources and more importantly took time. For some reports it resulted in breaches current `60 s` Skipper timeout and the restart of the report generator
  - Secondly `targets` connected to the `objectives` were a subject to N+1 problem because they were fetched lazily despite all of them were iterated over in the big loop
  - Bonus effect is doing the eager join on the above also spares the query to fetch all of the indicators for the current product as they are already fetched due to models configuration.